### PR TITLE
allow to compile bindings with system-wide hawktracer (#5)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04]
-        features: ["", --features=generate_bindings]
+        features: ["", --features=generate_bindings, --features="generate_bindings pkg-config", --features=pkg-config]
     
     steps:
     - uses: actions/checkout@v1
@@ -23,7 +23,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        features: ["", --features=generate_bindings]
+        features: ["", --features=generate_bindings, --features="generate_bindings pkg-config", --features=pkg-config]
     
     steps:
     - uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,16 @@ license = "MIT/Apache-2.0"
 
 [build-dependencies]
 cmake = "0.1"
+itertools = "0.8"
 
 [build-dependencies.bindgen]
 version = "0.37.0"
 optional = true
 
+[build-dependencies.pkg-config]
+optional = true
+version = "0.3"
+
 [features]
 generate_bindings=["bindgen"]
+non-cargo = []

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,13 @@
 extern crate bindgen;
 extern crate cmake;
 
+#[cfg(feature = "pkg-config")]
+extern crate pkg_config;
+extern crate itertools;
+
 use std::env;
 use std::path::PathBuf;
+use itertools::Itertools;
 
 //In order to build 64 bit hawktracer:
 // mkdir build
@@ -11,34 +16,20 @@ use std::path::PathBuf;
 // cmake .. -G "Visual Studio 15 2017 Win64" -T v141,host=x64
 // cmake --build .
 fn main() {
-    build_project();
-    let mut extra_include_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    extra_include_path.push("build");
-    extra_include_path.push("lib");
-    extra_include_path.push("include");
+    let (main_header_path, header_paths) = if cfg!(feature = "pkg-config") {
+        pkg_config()
+    } else {
+        build_project();
+        let mut extra_include_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+        extra_include_path.push("build");
+        extra_include_path.push("lib");
+        extra_include_path.push("include");
+        ("hawktracer/lib/include/hawktracer.h", vec![extra_include_path, PathBuf::from("./hawktracer/lib/include/")])
+    };
 
-    #[cfg(feature = "generate_bindings")]
-    {
-        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-        let bindings = bindgen::Builder::default()
-            .header("hawktracer/lib/include/hawktracer.h")
-            .clang_arg("-I./hawktracer/lib/include/")
-            .clang_arg(format!("-I{}", extra_include_path.display()))
-            .blacklist_type("max_align_t")
-            .generate()
-            .expect("Unable to generate bindings");
-        println!("Manifest dir: {:?}", manifest_dir);
+    println!("cargo:include={}", header_paths.iter().map(|p| p.display().to_string()).join(";"));
 
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("bindings.rs"))
-            .expect("Couldn't write bindings!");
-    }
-
-    #[cfg(not(feature = "generate_bindings"))]
-    {
-        copy_pregenerated_bindings();
-    }
+    generate_bindings(main_header_path, header_paths);
 
     let mut build_output_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     build_output_path.push("build");
@@ -74,7 +65,11 @@ fn main() {
         "cargo:rustc-link-search=all={}",
         build_output_path.display()
     );
-    println!("cargo:rustc-link-lib=static=hawktracer");
+    if cfg!(feature = "pkg-config") {
+        println!("cargo:rustc-link-lib=hawktracer");
+    } else {
+        println!("cargo:rustc-link-lib=static=hawktracer");
+    }
 }
 
 fn build_project() {
@@ -95,8 +90,29 @@ fn build_project() {
         .build();
 }
 
+#[cfg(feature = "generate_bindings")]
+fn generate_bindings(main_header_path: &str, header_paths: Vec<PathBuf>) {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let bindings = bindgen::Builder::default()
+        .header(main_header_path)
+        .clang_args(
+            header_paths
+                .into_iter()
+                .map(|path| format!("-I{}", path.display())),
+        )
+        .blacklist_type("max_align_t")
+        .generate()
+        .expect("Unable to generate bindings");
+    println!("Manifest dir: {:?}", manifest_dir);
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}
+
 #[cfg(not(feature = "generate_bindings"))]
-fn copy_pregenerated_bindings() {
+fn generate_bindings(_main_header_path: &str, _header_paths: Vec<PathBuf>) {
     use std::fs;
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let crate_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -105,4 +121,18 @@ fn copy_pregenerated_bindings() {
         out_path.join("bindings.rs"),
     )
     .expect("Couldn't find pregenerated bindings!");
+}
+
+#[cfg(feature = "pkg-config")]
+fn pkg_config() -> (&'static str, Vec<PathBuf>) {
+    let library = pkg_config::Config::new()
+        .cargo_metadata(!cfg!(feature = "non-cargo"))
+        .probe("hawktracer")
+        .expect("Can't probe for hawktracer in pkg-config");
+    ("wrapper.h", library.include_paths)
+}
+
+#[cfg(not(feature = "pkg-config"))]
+fn pkg_config() -> (&'static str, Vec<PathBuf>) {
+    unimplemented!()
 }

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,0 +1,1 @@
+#include <hawktracer.h>


### PR DESCRIPTION
Tested locally by running following script:
```bash
#!/bin/bash

feature_combinations=(
    '--features pkg-config generate_bindings'
    '--features pkg-config'
    '--features generate_bindings'
    '')

for features in "${feature_combinations[@]}"
do
    cargo test $features
    if [ $? -ne 0 ];
    then
	echo "Test for features \"$features\" failed"
	exit 1
    fi
done
```
If there are any integration tests that I could run, I'm happy to do that as well.