### PR TITLE
Upgrade to bindgen 0.56.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cmake = "0.1"
 itertools = "0.8"
 
 [build-dependencies.bindgen]
-version = "0.53.1"
+version = "0.56"
 optional = true
 
 [build-dependencies.pkg-config]


### PR DESCRIPTION
Upgrading the bindgen version does not require other code changes.

This PR also supersedes https://github.com/AlexEne/rust_hawktracer_sys/pull/12, which was merged to master, but not into main (probably by accident).